### PR TITLE
Use IP-API.com instead iptolocation

### DIFF
--- a/src/Config/visitlog.php
+++ b/src/Config/visitlog.php
@@ -24,6 +24,8 @@ return array(
     | and Browser info.
     |
     | Note: For requests from same IP, it will be cached so no further request is made to http://freegeoip.net
+    | 
+    | UPDATE: If ip_api is set to "true", it will ignore the iptolocation config.
     |
     */
 

--- a/src/Config/visitlog.php
+++ b/src/Config/visitlog.php
@@ -27,7 +27,10 @@ return array(
     |
     */
 
-    'iptolocation' => true,
+    // FREE IP API - https://ip-api.com/
+    'ip_api' => true,
+
+    'iptolocation' => false,
     'token' => 'PASTE_YOUR_TOKEN', // get your token here: https://ipstack.com/
 
     /*

--- a/src/Views/index.blade.php
+++ b/src/Views/index.blade.php
@@ -53,7 +53,7 @@
 
             <table cellspacing="0" width="100%" id="table-log"
                    class="table table-striped table-bordered table-sm table-hover table-condensed dt-responsive nowrap">
-                @if (config('visitlog.iptolocation'))
+                @if (config('visitlog.iptolocation') || config('visitlog.ip_api'))
                     <thead>
                     <tr>
                         <th>#</th>

--- a/src/VisitLog.php
+++ b/src/VisitLog.php
@@ -11,6 +11,7 @@ class VisitLog
     protected $browser = null;
     protected $cachePrefix = 'visitlog';
     protected $freegeoipUrl = 'http://api.ipstack.com';
+    protected $ipApiUrl = 'http://ip-api.com/';
     protected $tokenString = '&output=json&legacy=1';
 
     /**
@@ -100,7 +101,8 @@ class VisitLog
     {
         $ip = $this->getUserIP();
         $cacheKey = $this->cachePrefix . $ip;
-        $url = $this->freegeoipUrl . '/' . $ip . '?' . '&access_key=' . config('visitlog.token') . $this->tokenString;
+        $url_freegeoip = $this->freegeoipUrl . '/' . $ip . '?' . '&access_key=' . config('visitlog.token') . $this->tokenString;
+        $url_ipApi = $this->ipApiUrl . '/json/' . $ip;
 
         // basic info
         $data = [
@@ -109,26 +111,60 @@ class VisitLog
             'os' => $this->browser->getPlatform() ?: 'Unknown',
         ];
 
-        // info from http://freegeoip.net
-        if (config('visitlog.iptolocation')) {
+        // info from https://ip-api.com/
+        if (config('visitlog.ip_api')) {
             if (config('visitlog.cache')) {
-                $freegeoipData = unserialize(Cache::get($cacheKey));
+                $ipApiCacheKey = $cacheKey . '_apiip';
+                $ipApiData = unserialize(Cache::get($ipApiCacheKey));
 
-                if (!$freegeoipData) {
-                    $freegeoipData = @json_decode(file_get_contents($url), true);
+                if (!$ipApiData) {
+                    $ipApiData = @json_decode(file_get_contents($url_ipApi), true);
 
-                    if ($freegeoipData) {
-                        Cache::forever($cacheKey, serialize($freegeoipData));
+                    if ($ipApiData) {
+                        Cache::forever($ipApiCacheKey, serialize($ipApiData));
                     }
                 }
             } else {
-                $freegeoipData = @json_decode(file_get_contents($url), true);
+                $ipApiData = @json_decode(file_get_contents($url_ipApi), true);
             }
 
-            if ($freegeoipData) {
-                $data = array_merge($data, $freegeoipData);
+            if ($ipApiData && $ipApiData['status'] == 'success') {
+                $parsedData = [
+                    'country_name' => $ipApiData['country'],
+                    'region_name' => $ipApiData['regionName'],
+                    'city' => $ipApiData['city'],
+                    'zip_code' => $ipApiData['zip'],
+                    'time_zone' => $ipApiData['timezone'],
+                    'latitude' => $ipApiData['lat'],
+                    'longitude' => $ipApiData['lon'],
+                ];
+
+                $data = array_merge($data, $parsedData);
+            }
+        } else {
+            // info from http://freegeoip.net
+            if (config('visitlog.iptolocation')) {
+                if (config('visitlog.cache')) {
+                    $freegeoipCacheKey = $cacheKey . '_freegeoip';
+                    $freegeoipData = unserialize(Cache::get($freegeoipCacheKey));
+    
+                    if (!$freegeoipData) {
+                        $freegeoipData = @json_decode(file_get_contents($url_freegeoip), true);
+    
+                        if ($freegeoipData) {
+                            Cache::forever($freegeoipCacheKey, serialize($freegeoipData));
+                        }
+                    }
+                } else {
+                    $freegeoipData = @json_decode(file_get_contents($url_freegeoip), true);
+                }
+    
+                if ($freegeoipData) {
+                    $data = array_merge($data, $freegeoipData);
+                }
             }
         }
+
 
         $userData = $this->getUser();
 

--- a/src/VisitLog.php
+++ b/src/VisitLog.php
@@ -11,7 +11,7 @@ class VisitLog
     protected $browser = null;
     protected $cachePrefix = 'visitlog';
     protected $freegeoipUrl = 'http://api.ipstack.com';
-    protected $ipApiUrl = 'http://ip-api.com/';
+    protected $ipApiUrl = 'http://ip-api.com';
     protected $tokenString = '&output=json&legacy=1';
 
     /**


### PR DESCRIPTION
I've modified the package to allow to use [ip-api.com](http://ip-api.com), another IP geolocation tool. It's free and don't require any token, the only **limit is 45 requests per minute**. 

In the config/visitlog.php file, if the flag `ip_api` is set `true`, it will ignore the flag `iptolocation` .